### PR TITLE
[FIX] restore notice creation features and enhance UI components

### DIFF
--- a/src/pages/Notices/NoticesList.css
+++ b/src/pages/Notices/NoticesList.css
@@ -326,6 +326,163 @@
   to { transform: rotate(360deg); }
 }
 
+/* restored notice-create features */
+.btn-primary {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.btn-secondary {
+  background: #f1f5f9;
+  color: #334155;
+  border: 1px solid #e2e8f0;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: #e2e8f0;
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled,
+.btn-add:disabled,
+.reset-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.drawer-close {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #64748b;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.drawer-status {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.drawer-status.success {
+  background: #ecfdf5;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+
+.drawer-status.error {
+  background: #fef2f2;
+  color: #b91c1c;
+  border: 1px solid #fecaca;
+}
+
+.drawer-status.info {
+  background: #eff6ff;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+}
+
+.drawer-status.warning {
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+
+.success-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.success-panel h4 {
+  margin: 0;
+  color: #14532d;
+}
+
+.success-panel p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.success-icon {
+  color: #16a34a;
+}
+
+.dong-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dong-helper {
+  margin-left: 8px;
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+.dong-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.dong-actions button {
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  color: #475569;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.dong-actions button:hover {
+  background: #f8fafc;
+}
+
+.dong-grid-select {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(92px, 1fr));
+  gap: 8px;
+}
+
+.dong-item-select {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  background: #fff;
+}
+
+.dong-item-select.selected {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.helper-text {
+  margin-top: 8px;
+  font-size: 0.84rem;
+  color: #64748b;
+}
+
+.helper-text.success {
+  color: #166534;
+}
+
 /* 모바일 대응 */
 @media (max-width: 640px) {
   .filter-group {

--- a/src/pages/Notices/NoticesList.jsx
+++ b/src/pages/Notices/NoticesList.jsx
@@ -6,17 +6,21 @@ import {
   updateNotice,
   deleteNotice,
   getNoticeLogs,
+  sendNoticeAlert,
+  getDongListByApartment,
 } from "../../services/noticeApi";
-import { 
-  Search, 
-  Plus, 
-  RotateCcw, 
-  X, 
-  FileText, 
+import { getMyApartmentInfo } from "../../services/adminApi";
+import { useAuth } from "../../context/AuthContext";
+import {
+  Search,
+  Plus,
+  RotateCcw,
+  X,
+  FileText,
   Send,
   History,
   CheckCircle,
-  AlertCircle
+  AlertCircle,
 } from "lucide-react";
 import "./NoticesList.css";
 
@@ -24,92 +28,166 @@ const TITLE_MAX = 100;
 const CONTENT_MAX = 2000;
 
 export default function NoticesList() {
+  const { user } = useAuth();
   const [notices, setNotices] = useState([]);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState("");
-  
-  // KPI 통계 상태
+
+  // KPI 통계
   const [stats, setStats] = useState({ totalSent: 0, readCount: 0, unreadCount: 0 });
 
-  // Drawer 관련 상태
-  const [drawerMode, setDrawerMode] = useState(null); 
+  // Drawer
+  const [drawerMode, setDrawerMode] = useState(null);
   const [selectedNotice, setSelectedNotice] = useState(null);
-  const [drawerTab, setDrawerTab] = useState("content"); 
+  const [drawerTab, setDrawerTab] = useState("content");
   const [drawerLoading, setDrawerLoading] = useState(false);
-  
+
   const [formValues, setFormValues] = useState({ title: "", content: "" });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  
+
   const [logs, setLogs] = useState([]);
   const [logLoading, setLogLoading] = useState(false);
 
-  // 데이터 로드 및 통계 계산
+  // 동 선택 관련
+  const [apartmentId, setApartmentId] = useState(null);
+  const [dongs, setDongs] = useState([]);
+  const [selectedDongIds, setSelectedDongIds] = useState([]);
+  const [dongLoading, setDongLoading] = useState(false);
+
+  // 생성 직후 즉시 발송
+  const [createdNoticeId, setCreatedNoticeId] = useState(null);
+  const [status, setStatus] = useState({ type: "idle", message: "" });
+
   const loadData = useCallback(async () => {
-    if (loading) return;
     setLoading(true);
-    setError("");
+    setStatus({ type: "idle", message: "" });
     try {
-      const [noticeRes, logRes] = await Promise.all([
-        getNoticeList(),
-        getNoticeLogs()
-      ]);
-      
+      const [noticeRes, logRes] = await Promise.all([getNoticeList(), getNoticeLogs()]);
+
       const noticeList = Array.isArray(noticeRes) ? noticeRes : [];
       const logList = Array.isArray(logRes) ? logRes : [];
-      
+
       setNotices(noticeList);
-      
-      const read = logList.filter(l => l.read).length;
+      const read = logList.filter((log) => log.read).length;
       setStats({
         totalSent: logList.length,
         readCount: read,
-        unreadCount: logList.length - read
+        unreadCount: logList.length - read,
       });
-    } catch (err) {
-      setError("데이터를 불러오지 못했습니다.");
+    } catch {
+      setStatus({ type: "error", message: "데이터를 불러오지 못했습니다." });
     } finally {
       setLoading(false);
     }
-  }, [loading]);
+  }, []);
 
-  useEffect(() => { 
-    loadData(); 
-  }, []); // 초기 1회 로드
+  const loadDongs = useCallback(async (aptId) => {
+    if (!aptId) return;
+    setDongLoading(true);
+    try {
+      const result = await getDongListByApartment(aptId);
+      const dongList = Array.isArray(result) ? result : [];
+      setDongs(dongList);
+    } catch {
+      setDongs([]);
+      setSelectedDongIds([]);
+      setStatus({
+        type: "warning",
+        message: "동 목록을 불러오지 못했습니다. 선택하지 않으면 전체 허용 동으로 발송됩니다.",
+      });
+    } finally {
+      setDongLoading(false);
+    }
+  }, []);
 
-  // 새로고침 핸들러
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveApartmentId = async () => {
+      const contextApartmentId = Number(user?.apartmentId);
+      if (Number.isFinite(contextApartmentId) && contextApartmentId > 0) {
+        if (cancelled) return;
+        setApartmentId(contextApartmentId);
+        await loadDongs(contextApartmentId);
+        return;
+      }
+
+      const apartmentInfo = await getMyApartmentInfo();
+      const fallbackApartmentId = Number(apartmentInfo?.apartmentId ?? apartmentInfo?.id);
+      if (Number.isFinite(fallbackApartmentId) && fallbackApartmentId > 0) {
+        if (cancelled) return;
+        setApartmentId(fallbackApartmentId);
+        await loadDongs(fallbackApartmentId);
+        return;
+      }
+
+      if (cancelled) return;
+      setApartmentId(null);
+      setDongs([]);
+      setSelectedDongIds([]);
+      setStatus({
+        type: "info",
+        message: "아파트 정보를 확인할 수 없습니다. 선택하지 않으면 전체 허용 동으로 발송됩니다.",
+      });
+    };
+
+    resolveApartmentId();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.apartmentId, loadDongs]);
+
   const handleRefresh = () => {
-    setSearch(""); // 검색어 초기화
+    setSearch("");
     loadData();
   };
 
-  const loadNoticeLogs = async (noticeId) => {
+  const toggleDong = (dongId) => {
+    setSelectedDongIds((prev) =>
+      prev.includes(dongId) ? prev.filter((id) => id !== dongId) : [...prev, dongId],
+    );
+  };
+
+  const selectAllDongs = () => setSelectedDongIds(dongs.map((d) => d.id));
+  const clearAllDongs = () => setSelectedDongIds([]);
+
+  const loadNoticeLogs = useCallback(async (noticeId) => {
     setLogLoading(true);
     try {
       const allLogs = await getNoticeLogs();
-      const filtered = allLogs.filter(log => log.noticeId === noticeId || log.title === selectedNotice?.title);
+      const parsedLogs = Array.isArray(allLogs) ? allLogs : [];
+      const filtered = parsedLogs.filter(
+        (log) => log.noticeId === noticeId || log.title === selectedNotice?.title,
+      );
       setLogs(filtered);
-    } catch (err) {
-      console.error("로그 로드 실패");
+    } catch {
+      setLogs([]);
     } finally {
       setLogLoading(false);
     }
-  };
+  }, [selectedNotice?.title]);
 
   useEffect(() => {
     if (drawerTab === "logs" && selectedNotice?.noticeId) {
       loadNoticeLogs(selectedNotice.noticeId);
     }
-  }, [drawerTab, selectedNotice]);
+  }, [drawerTab, selectedNotice, loadNoticeLogs]);
 
-  const openDrawer = async (mode, noticeId = null) => {
+  const openDrawer = async (mode, noticeId = null, initialTab = "content") => {
     setError("");
+    setCreatedNoticeId(null);
+    setSelectedNotice(null);
     setDrawerMode(mode);
-    setDrawerTab("content");
-    
+    setDrawerTab(initialTab);
+
     if (mode === "create") {
-      setSelectedNotice(null);
       setFormValues({ title: "", content: "" });
+      setSelectedDongIds([]);
       return;
     }
 
@@ -119,7 +197,8 @@ export default function NoticesList() {
         const data = await getNotice(noticeId);
         setSelectedNotice(data);
         setFormValues({ title: data.title ?? "", content: data.content ?? "" });
-      } catch (err) {
+        setSelectedDongIds(Array.isArray(data?.dongIds) ? data.dongIds : []);
+      } catch {
         setError("공지 정보를 불러오지 못했습니다.");
       } finally {
         setDrawerLoading(false);
@@ -131,23 +210,47 @@ export default function NoticesList() {
     if (saving) return;
     setDrawerMode(null);
     setSelectedNotice(null);
+    setCreatedNoticeId(null);
+    setSelectedDongIds([]);
     setLogs([]);
     setError("");
   };
 
   const handleSave = async () => {
-    if (!formValues.title.trim() || !formValues.content.trim()) {
+    const title = formValues.title.trim();
+    const content = formValues.content.trim();
+    if (!title || !content) {
       setError("제목과 내용을 입력해주세요.");
       return;
     }
+
+    const payload = {
+      title,
+      content,
+      dongIds: selectedDongIds.length ? selectedDongIds : undefined,
+    };
+
     try {
       setSaving(true);
-      if (drawerMode === "create") await createNotice(formValues);
-      else await updateNotice(selectedNotice.noticeId, formValues);
+      if (drawerMode === "create") {
+        const response = await createNotice(payload);
+        const newNoticeId = response?.noticeId ?? null;
+        setCreatedNoticeId(newNoticeId);
+        setSelectedNotice({ noticeId: newNoticeId, title, content });
+        setDrawerMode("created");
+        setStatus({
+          type: "success",
+          message: `공지가 성공적으로 등록되었습니다. (ID: ${newNoticeId ?? "-"})`,
+        });
+      } else {
+        await updateNotice(selectedNotice.noticeId, payload);
+        setStatus({ type: "success", message: "공지사항이 수정되었습니다." });
+        closeDrawer();
+      }
       await loadData();
-      closeDrawer();
     } catch (err) {
       setError("저장 중 오류가 발생했습니다.");
+      setStatus({ type: "error", message: err?.message || "저장 중 오류가 발생했습니다." });
     } finally {
       setSaving(false);
     }
@@ -159,50 +262,74 @@ export default function NoticesList() {
       setSaving(true);
       await deleteNotice(selectedNotice.noticeId);
       await loadData();
+      setStatus({ type: "success", message: "공지사항이 삭제되었습니다." });
       closeDrawer();
-    } catch (err) {
+    } catch {
       setError("삭제 중 오류가 발생했습니다.");
     } finally {
       setSaving(false);
     }
   };
 
+  const handleSendNow = async () => {
+    if (!createdNoticeId) return;
+    setError("");
+    try {
+      setSaving(true);
+      const payload = selectedDongIds.length ? { dongIds: selectedDongIds } : {};
+      const response = await sendNoticeAlert(createdNoticeId, payload);
+      setStatus({
+        type: "success",
+        message: response?.message || `알림 발송 완료 (${response?.sentCount ?? 0}건)`,
+      });
+      await loadData();
+    } catch (err) {
+      setError(err?.message || "알림 발송에 실패했습니다.");
+      setStatus({ type: "error", message: err?.message || "알림 발송에 실패했습니다." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openCreatedLogs = async () => {
+    if (!createdNoticeId) return;
+    await openDrawer("view", createdNoticeId, "logs");
+  };
+
   const filteredNotices = useMemo(() => {
     const q = search.toLowerCase();
-    return notices.filter(n => 
-      (n.title ?? "").toLowerCase().includes(q) || 
-      (n.content ?? "").toLowerCase().includes(q)
+    return notices.filter(
+      (n) =>
+        (n.title ?? "").toLowerCase().includes(q) || (n.content ?? "").toLowerCase().includes(q),
     );
   }, [notices, search]);
 
   return (
     <div className="bill-dashboard">
-      
-      {/* KPI 섹션 */}
       <div className="bill-kpi-section">
         <div className="bill-kpi-card">
-          <FileText size={24} style={{color: '#3b82f6'}} />
+          <FileText size={24} style={{ color: "#3b82f6" }} />
           <div>
             <div className="kpi-label">전체 공지</div>
             <div className="kpi-value">{notices.length}건</div>
           </div>
         </div>
         <div className="bill-kpi-card">
-          <Send size={24} style={{color: '#10b981'}} />
+          <Send size={24} style={{ color: "#10b981" }} />
           <div>
             <div className="kpi-label">총 발송</div>
             <div className="kpi-value">{stats.totalSent}회</div>
           </div>
         </div>
         <div className="bill-kpi-card">
-          <CheckCircle size={24} style={{color: '#22c55e'}} />
+          <CheckCircle size={24} style={{ color: "#22c55e" }} />
           <div>
             <div className="kpi-label">확인 수</div>
             <div className="kpi-value">{stats.readCount}건</div>
           </div>
         </div>
         <div className="bill-kpi-card danger">
-          <AlertCircle size={24} style={{color: '#ef4444'}} />
+          <AlertCircle size={24} style={{ color: "#ef4444" }} />
           <div>
             <div className="kpi-label">미확인 수</div>
             <div className="kpi-value">{stats.unreadCount}건</div>
@@ -210,27 +337,22 @@ export default function NoticesList() {
         </div>
       </div>
 
-      {/* 검색 및 필터 바 */}
       <div className="bill-filter-card">
         <div className="bill-filter-form">
           <div className="input-group">
             <div className="search-wrapper">
               <Search size={18} className="search-icon" />
-              <input 
-                type="text" 
-                placeholder="공지 제목 또는 내용 검색..." 
-                value={search} 
+              <input
+                type="text"
+                placeholder="공지 제목 또는 내용 검색..."
+                value={search}
                 onChange={(e) => setSearch(e.target.value)}
               />
             </div>
           </div>
           <div className="button-group">
-            <button 
-              className="reset-btn" 
-              onClick={handleRefresh}
-              disabled={loading}
-            >
-              <RotateCcw size={16} className={loading ? "spin" : ""} /> 
+            <button className="reset-btn" onClick={handleRefresh} disabled={loading}>
+              <RotateCcw size={16} className={loading ? "spin" : ""} />
               {loading ? "로딩 중" : "새로고침"}
             </button>
             <button className="btn-add" onClick={() => openDrawer("create")}>
@@ -238,59 +360,94 @@ export default function NoticesList() {
             </button>
           </div>
         </div>
+
+        {status.type !== "idle" && (
+          <div className={`drawer-status ${status.type}`}>{status.message}</div>
+        )}
       </div>
 
-      {/* 리스트 테이블 */}
       <div className="bill-table-card">
         <div className="table-responsive">
           <table className="bill-table">
             <thead>
               <tr>
-                <th style={{ width: '60px' }}>번호</th>
-                <th style={{ width: '200px' }}>제목</th>
+                <th style={{ width: "60px" }}>번호</th>
+                <th style={{ width: "200px" }}>제목</th>
                 <th>공지 내용</th>
-                <th style={{ width: '120px' }}>작성자</th>
-                <th style={{ width: '120px' }}>등록일</th>
-                <th style={{ width: '100px' }}>관리</th>
+                <th style={{ width: "120px" }}>작성자</th>
+                <th style={{ width: "120px" }}>등록일</th>
+                <th style={{ width: "100px" }}>관리</th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
-                <tr><td colSpan="6" className="no-data">데이터를 불러오는 중입니다...</td></tr>
+                <tr>
+                  <td colSpan="6" className="no-data">
+                    데이터를 불러오는 중입니다...
+                  </td>
+                </tr>
               ) : filteredNotices.length > 0 ? (
                 filteredNotices.map((n, idx) => (
-                  <tr key={n.noticeId} className="row-hover" onClick={() => openDrawer("view", n.noticeId)}>
-                    <td>{notices.length - idx}</td>
+                  <tr
+                    key={n.noticeId}
+                    className="row-hover"
+                    onClick={() => openDrawer("view", n.noticeId)}
+                  >
+                    <td>{filteredNotices.length - idx}</td>
                     <td className="cell-title">{n.title}</td>
                     <td className="cell-content">{n.content}</td>
                     <td>{n.authorName}</td>
                     <td>{n.createdAt ? new Date(n.createdAt).toLocaleDateString() : "-"}</td>
                     <td>
-                      <button className="sm-detail-btn">확인여부</button>
+                      <button
+                        className="sm-detail-btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openDrawer("view", n.noticeId, "logs");
+                        }}
+                      >
+                        확인여부
+                      </button>
                     </td>
                   </tr>
                 ))
               ) : (
-                <tr><td colSpan="6" className="no-data">등록된 공지가 없습니다.</td></tr>
+                <tr>
+                  <td colSpan="6" className="no-data">
+                    등록된 공지가 없습니다.
+                  </td>
+                </tr>
               )}
             </tbody>
           </table>
         </div>
       </div>
 
-      {/* Drawer 영역 */}
       <div className={`side-drawer ${drawerMode ? "open" : ""}`}>
         <div className="drawer-header">
-          <h3>{drawerMode === "create" ? "새 공지 작성" : "공지사항 상세"}</h3>
-          <button className="drawer-close" onClick={closeDrawer}><X size={24} /></button>
+          <h3>
+            {drawerMode === "create" && "새 공지 작성"}
+            {drawerMode === "edit" && "공지사항 수정"}
+            {drawerMode === "created" && "공지 등록 완료"}
+            {drawerMode === "view" && "공지사항 상세"}
+          </h3>
+          <button className="drawer-close" onClick={closeDrawer} disabled={saving}>
+            <X size={24} />
+          </button>
         </div>
 
-        {drawerMode !== "create" && (
+        {drawerMode !== "create" && drawerMode !== "created" && (
           <div className="drawer-tabs">
-            <button className={drawerTab === "content" ? "active" : ""} onClick={() => setDrawerTab("content")}>
+            <button
+              className={drawerTab === "content" ? "active" : ""}
+              onClick={() => setDrawerTab("content")}
+            >
               <FileText size={16} /> 내용 보기
             </button>
-            <button className={drawerTab === "logs" ? "active" : ""} onClick={() => setDrawerTab("logs")}>
+            <button
+              className={drawerTab === "logs" ? "active" : ""}
+              onClick={() => setDrawerTab("logs")}
+            >
               <History size={16} /> 발송 내역
             </button>
           </div>
@@ -299,41 +456,140 @@ export default function NoticesList() {
         <div className="drawer-body">
           {error && <div className="error-msg">{error}</div>}
           
-          {drawerLoading ? (
+          {drawerLoading && drawerMode !== "created" ? (
             <div className="loading-box">공지 정보를 로딩 중...</div>
+          ) : drawerMode === "created" ? (
+            <div className="success-panel">
+              <CheckCircle size={42} className="success-icon" />
+              <h4>공지 등록이 완료되었습니다.</h4>
+              <p>
+                {createdNoticeId ? `공지 ID: ${createdNoticeId}` : "공지 ID를 확인할 수 없습니다."}
+                <br />
+                선택된 동이 없으면 전체 허용 동으로 발송됩니다.
+              </p>
+              <div className="drawer-actions">
+                <button
+                  className="btn-primary"
+                  onClick={handleSendNow}
+                  disabled={saving || !createdNoticeId}
+                >
+                  {saving ? "발송 중..." : "지금 알림 발송"}
+                </button>
+                <button className="btn-secondary" onClick={() => openDrawer("create")} disabled={saving}>
+                  새 공지 작성
+                </button>
+                <button className="btn-secondary" onClick={openCreatedLogs} disabled={!createdNoticeId || saving}>
+                  발송 내역 보기
+                </button>
+              </div>
+            </div>
           ) : drawerTab === "content" ? (
             <div className="drawer-content">
               <div className="field">
                 <label>제목 ({formValues.title.length}/{TITLE_MAX})</label>
-                <input 
+                <input
                   disabled={drawerMode === "view"}
-                  value={formValues.title} 
-                  onChange={(e) => setFormValues({...formValues, title: e.target.value})}
-                  placeholder="제목을 입력하세요" 
+                  value={formValues.title}
+                  onChange={(e) =>
+                    setFormValues({
+                      ...formValues,
+                      title: e.target.value.slice(0, TITLE_MAX),
+                    })
+                  }
+                  placeholder="제목을 입력하세요"
                 />
               </div>
-              <div className="field" style={{marginTop: '20px'}}>
+              <div className="field" style={{ marginTop: "20px" }}>
                 <label>내용 ({formValues.content.length}/{CONTENT_MAX})</label>
-                <textarea 
+                <textarea
                   disabled={drawerMode === "view"}
                   rows={15}
-                  value={formValues.content} 
-                  onChange={(e) => setFormValues({...formValues, content: e.target.value})}
-                  placeholder="공지 내용을 입력하세요" 
+                  value={formValues.content}
+                  onChange={(e) =>
+                    setFormValues({
+                      ...formValues,
+                      content: e.target.value.slice(0, CONTENT_MAX),
+                    })
+                  }
+                  placeholder="공지 내용을 입력하세요"
                 />
               </div>
-              <div className="drawer-actions" style={{marginTop: '30px'}}>
+
+              <div className="field" style={{ marginTop: "20px" }}>
+                <div className="dong-header">
+                  <label>
+                    발송 대상 동 (선택)
+                    {apartmentId && <span className="dong-helper">아파트 #{apartmentId}</span>}
+                  </label>
+                  {dongs.length > 0 && drawerMode !== "view" && (
+                    <div className="dong-actions">
+                      <button type="button" onClick={selectAllDongs}>
+                        전체 선택
+                      </button>
+                      <button type="button" onClick={clearAllDongs}>
+                        선택 해제
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                {dongLoading && <div className="helper-text">동 목록을 불러오는 중...</div>}
+
+                {!dongLoading && dongs.length > 0 && (
+                  <>
+                    <div className="dong-grid-select">
+                      {dongs.map((dong) => {
+                        const isSelected = selectedDongIds.includes(dong.id);
+                        return (
+                          <label
+                            key={dong.id}
+                            className={`dong-item-select ${isSelected ? "selected" : ""}`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={() => toggleDong(dong.id)}
+                              disabled={saving || drawerMode === "view"}
+                            />
+                            <span>{dong.dongNo}동</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                    {selectedDongIds.length > 0 && (
+                      <div className="helper-text success">{selectedDongIds.length}개 동 선택됨</div>
+                    )}
+                  </>
+                )}
+
+                {!dongLoading && dongs.length === 0 && (
+                  <div className="helper-text">
+                    동 목록이 없습니다. 선택하지 않으면 전체 허용 동으로 발송됩니다.
+                  </div>
+                )}
+              </div>
+
+              <div className="drawer-actions" style={{ marginTop: "30px" }}>
                 {drawerMode === "view" ? (
                   <>
-                    <button className="btn-primary" onClick={() => setDrawerMode("edit")}>편집</button>
-                    <button className="btn-delete-sm" onClick={handleDelete}>삭제</button>
+                    <button className="btn-primary" onClick={() => setDrawerMode("edit")}>
+                      편집
+                    </button>
+                    <button className="btn-delete-sm" onClick={handleDelete}>
+                      삭제
+                    </button>
                   </>
                 ) : (
                   <>
                     <button className="btn-primary" onClick={handleSave} disabled={saving}>
-                      {saving ? "저장 중..." : "저장"}
+                      {saving ? "저장 중..." : drawerMode === "create" ? "등록" : "저장"}
                     </button>
-                    <button className="btn-secondary" onClick={() => drawerMode === "edit" ? setDrawerMode("view") : closeDrawer()}>취소</button>
+                    <button
+                      className="btn-secondary"
+                      onClick={() => (drawerMode === "edit" ? setDrawerMode("view") : closeDrawer())}
+                    >
+                      취소
+                    </button>
                   </>
                 )}
               </div>
@@ -345,7 +601,7 @@ export default function NoticesList() {
                 <div>로그 로딩 중...</div>
               ) : logs.length > 0 ? (
                 <div className="log-list">
-                  {logs.map(log => (
+                  {logs.map((log) => (
                     <div key={log.id} className="log-item">
                       <div className="log-info">
                         <strong>수신: {log.recipientId}</strong>
@@ -364,6 +620,7 @@ export default function NoticesList() {
           )}
         </div>
       </div>
+
       {drawerMode && <div className="drawer-backdrop" onClick={closeDrawer} />}
     </div>
   );

--- a/src/services/adminApi.js
+++ b/src/services/adminApi.js
@@ -27,13 +27,13 @@ export const verifyOtp = (data) =>
  * 로그아웃
  */
 export const adminLogout = () =>
-  post("/api/admin/auth/logout"); 
+  post("/api/admin/account/logout", {}); 
 
 /**
  * Access 토큰 재발급
  */
 export const adminRefresh = () =>
-  post("/api/admin/auth/refresh"); 
+  post("/api/admin/auth/refresh", {}); 
 
 /* ===========================
     Password

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,15 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:8080",
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const proxyTarget = env.VITE_PROXY_TARGET || "http://127.0.0.1:8080";
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        "/api": {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
NoticesList 리팩토링 과정에서 빠졌던 NoticeCreate 핵심 기능을 복원했습니다.

  - 공지 작성/수정 시 동 대상 선택 UI 추가 (전체 선택/해제, 선택 개수 표시)
  - create/update payload에 dongIds 반영
  - 공지 등록 직후 성공 패널 및 "지금 알림 발송(sendNoticeAlert)" 플로우 복원